### PR TITLE
Only decompress public keys from P2PK if they will be written

### DIFF
--- a/utxodump.go
+++ b/utxodump.go
@@ -361,7 +361,10 @@ func main() {
                 script := xor[offset:]
                 
                 // Decompress the public keys from P2PK scripts that were uncompressed originally. They got compressed just for storage in the database.
-                if (nsize == 4) || (nsize == 5) {
+                // Only decompress if the public key was uncompressed and
+                //   * Script field is selected or
+                //   * Address field is selected and p2pk addresses are enabled.
+                if (nsize == 4 || nsize == 5) && (fieldsSelected["script"] || (fieldsSelected["address"] && *p2pkaddresses)) {
                     script = keys.DecompressPublicKey(script)
                 }
                 


### PR DESCRIPTION
Hey, issue #32 was solved, but P2PK keys are being decompressed even if they won't be needed.
Changing it, so that only happens if `script` field was selected or (`address` field was and `p2pkaddresses` is enabled).