### PR TITLE
fixing overidentification of p2ms by moving the case statement below p2wpkh, p2wsh, p2tr.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,15 @@ count,txid,vout,amount,type,address
 
 ## Install
 
-First of all, you need to have a full copy of the blockchain. You also need to install LevelDB:
+First of all, you need to have a full copy of the blockchain, which you can get from installing and running bitcoind.
 
 ```
 sudo apt install bitcoind
+```
+
+You also need to install LevelDB to run this program:
+
+```
 sudo apt install libleveldb-dev
 ```
 
@@ -66,6 +71,15 @@ This will start dumping all of the UTXO database to a file called `utxodump.csv`
 
 **NOTE:** LevelDB wasn't designed to be accessed by multiple programs at the same time, so make sure `bitcoind` isn't running before you start (`bitcoin-cli stop` should do it).
 
+## Build
+
+If you prefer to build and run locally, clone the repo and build with Go:
+
+```
+$ git clone https://github.com/in3rsha/bitcoin-utxo-dump.git
+$ cd bitcoin-utxo-dump
+$ go build .
+```
 
 ## Usage
 

--- a/utxodump.go
+++ b/utxodump.go
@@ -440,11 +440,6 @@ func main() {
 		                        }
 		                    }
 
-		                // P2MS
-		                case len(script) > 0 && script[len(script)-1] == 174: // if there is a script and if the last opcode is OP_CHECKMULTISIG (174) (0xae)
-		                    scriptType = "p2ms"
-		                    scriptTypeCount["p2ms"] += 1
-
 		                // P2WPKH
 		                case nsize == 28 && script[0] == 0 && script[1] == 20: // P2WPKH (script type is 28, which means length of script is 22 bytes)
 		                    // 315,c016e8dcc608c638196ca97572e04c6c52ccb03a35824185572fe50215b80000,0,551005,3118,0,28,001427dab16cca30628d395ccd2ae417dc1fe8dfa03e
@@ -515,6 +510,11 @@ func main() {
 
 		                    scriptType = "p2tr"
 		                    scriptTypeCount["p2tr"] += 1
+
+		                // P2MS
+		                case len(script) > 0 && script[len(script)-1] == 174: // if there is a script and if the last opcode is OP_CHECKMULTISIG (174) (0xae)
+		                    scriptType = "p2ms"
+		                    scriptTypeCount["p2ms"] += 1
 
 		                // Non-Standard (if the script type hasn't been identified and set then it remains as an unknown "non-standard" script)
 		                default:


### PR DESCRIPTION
segwit scripts end in hashes that may end in `xAE` which is misinterpreted as `OP_CHECKSIG`. script type is reported as p2ms in these cases.

example: [ed35633eaa28f4452c4eb1b45df9f9667878f23e05a40116660bec381a000000](https://mempool.space/tx/ed35633eaa28f4452c4eb1b45df9f9667878f23e05a40116660bec381a000000) vout: 3

fix is simple enough: move the case statement below the segwit script types.

I also tweaked the README a bit, I hope it adds value.

before my change:
```bash
$ ./bitcoin-utxo-dump -db ~/scratch/bitcoin/node-data-copy/chainstate -f txid,vout,height,amount,script,type
...
Total UTXOs: 83310739
Total BTC:   19266337.75311853
Script Types:
 p2tr         318515
 non-standard 9565
 p2pk         47584
 p2pkh        47777074
 p2sh         15252482
 p2ms         516634
 p2wpkh       18273276
 p2wsh        1115609
```

after my change:
```bash
$ ./bitcoin-utxo-dump -db ~/scratch/bitcoin/node-data-copy/chainstate -f txid,vout,height,amount,script,type
...
Total UTXOs: 83310739
Total BTC:   19266337.75311853
Script Types:
 non-standard 9565
 p2pk         47584
 p2pkh        47777074
 p2sh         15252482
 p2ms         440424
 p2wpkh       18343108
 p2wsh        1120662
 p2tr         319840
```

difference:
```
 non-standard 0
 p2pk         0
 p2pkh        0
 p2sh         0
 p2ms         -76,210
 p2wpkh       +69,832
 p2wsh        +5,053
 p2tr         +1,325
```